### PR TITLE
No.2 Exception 対応

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -1,0 +1,5 @@
+spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+  resources:
+    add-mappings: false

--- a/src/main/kotlin/com/tsukioka/cypherhelloworld/advice/HelloWorldExceptionHandler.kt
+++ b/src/main/kotlin/com/tsukioka/cypherhelloworld/advice/HelloWorldExceptionHandler.kt
@@ -1,0 +1,20 @@
+package com.tsukioka.cypherhelloworld.advice
+
+import com.tsukioka.cypherhelloworld.entity.ErrorResponse
+import com.tsukioka.cypherhelloworld.entity.ErrorType
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.NoHandlerFoundException
+
+@RestControllerAdvice
+class HelloWorldExceptionHandler {
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun handler(ex: NoHandlerFoundException): ErrorResponse = ErrorResponse(ErrorType.NOT_FOUND.reason)
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handler(ex: Exception): ErrorResponse = ErrorResponse(ErrorType.INTERNAL_SERVER_ERROR.reason)
+}

--- a/src/main/kotlin/com/tsukioka/cypherhelloworld/entity/ErrorResponse.kt
+++ b/src/main/kotlin/com/tsukioka/cypherhelloworld/entity/ErrorResponse.kt
@@ -1,0 +1,5 @@
+package com.tsukioka.cypherhelloworld.entity
+
+data class ErrorResponse(
+    val reason: String,
+)

--- a/src/main/kotlin/com/tsukioka/cypherhelloworld/entity/ErrorType.kt
+++ b/src/main/kotlin/com/tsukioka/cypherhelloworld/entity/ErrorType.kt
@@ -1,0 +1,8 @@
+package com.tsukioka.cypherhelloworld.entity
+
+enum class ErrorType(
+    val reason: String
+) {
+    NOT_FOUND("no handler found"),
+    INTERNAL_SERVER_ERROR("something wrong ;-(")
+}


### PR DESCRIPTION
[Cypher: Spring BootCamp](https://confluence.askul.co.jp/display/AskulEngineers/Cypher%3A+Spring+BootCamp)のNo. 2

### 内容
- 設定していないPathにリクエストが来たときにHTTP Status 404でResponseをJsonで返却
- Applicationで例外が発生した際、HTTP Status 500でJsonを返却

### 実行結果
<img width="276" alt="cypher_task02_1" src="https://user-images.githubusercontent.com/86939965/140636145-1dd9fc9d-8844-4656-9851-ca9a93cd45c8.png">
<img width="365" alt="cypher_task02_2" src="https://user-images.githubusercontent.com/86939965/140636149-30ba2752-5555-4c0b-a1ac-93e88e7cf4aa.png">


